### PR TITLE
Change spelling of delimeter to delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Converts emoji in a string into textual descriptions.
 	emojiText.convert("🐱🐶"); // "[cat][dog]"
 
 	emojiText.convert("🐔 🌵", {
-  	delimeter: ':'
+  	delimiter: ':'
 	}); // ":chicken: :cactus:"
 
 	emojiText.convert("👻 🐴", {

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The string to convert, expected to have emoji encoded as UTF-8.
 {
 	before: '[', // character to use before field
 	after: ']', // character to use after field
-	delimeter: ':', // shortcut to set before + after to same char
+	delimiter: ':', // shortcut to set before + after to same char
 	field: 'name', // field to use name, description or emoji,
 	callback: function(emoji, data) {} // custom conversion callback
 }


### PR DESCRIPTION
While I was attempting to use this library it seemed that the `delimeter` flag wasn't working as expected. After taking a quick look through the code I noticed it checks for `delimiter` in `options` while the example in the README uses `delimeter`.
